### PR TITLE
Upgrade to 2.1 Preview2

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,1 +1,1 @@
-{ "sdk": { "version": "2.1.300-preview1-008174" } }
+{ "sdk": { "version": "2.1.300-preview2-008530" } }

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,9 @@
 # How to use
 ## Setup
-This repo depends on the 2.1 Preview1 SDK at the moment. This can lead to errors such as
+This repo depends on the 2.1 Preview2 SDK at the moment. This can lead to errors such as
 ```
 It was not possible to find any compatible framework version
-The specified framework 'Microsoft.AspNetCore.App', version '2.1.0-preview1-final' was not found.
+The specified framework 'Microsoft.AspNetCore.App', version '2.1.0-preview2-final' was not found.
   - Check application dependencies and target a framework version installed at:
       C:\Users\dougbu\.dotnet\x64\
   - The .NET framework can be installed from:
@@ -12,7 +12,7 @@ The specified framework 'Microsoft.AspNetCore.App', version '2.1.0-preview1-fina
       http://go.microsoft.com/fwlink/?LinkID=798306&clcid=0x409
 ```
 To avoid these issues:
-1. Download the SDK installer for your platform from https://www.microsoft.com/net/download/dotnet-core/sdk-2.1.300-preview1
+1. Download the SDK installer for your platform from https://www.microsoft.com/net/download/dotnet-core/sdk-2.1.300-preview2
 2. Install the SDK
 3. Ensure `dotnet` is now in your path e.g. `$env:Path` should include `C:\Program Files\dotnet` on Windows
 
@@ -27,6 +27,6 @@ The project in `webhooks-poc.sln` should just work. For example,
 ## Browse
 Default home pages are http://localhost:5000/ and https://localhost:5001/ when run from the command line.
 
-Use the home page to add some routes - these will be mapped to the 'github' reciever. The set of routes/actions will be updated each time you submit new data.
+Use the home page to add some routes - these will be mapped to the 'github' receiver. The set of routes/actions will be updated each time you submit new data.
 
 The "Dump Routes" action just redirects back to the home page. It's useful when debugging: Set a breakpoint in the action to examine the current routes.

--- a/src/SampleApp/Controllers/HomeController.cs
+++ b/src/SampleApp/Controllers/HomeController.cs
@@ -55,10 +55,12 @@ namespace SampleApp.Controllers
 
         public IActionResult DumpRoutes([FromServices] IActionDescriptorCollectionProvider actions)
         {
-            var items = actions.ActionDescriptors.Items;
-            foreach (var item in items)
+            var actionDescriptors = actions.ActionDescriptors.Items;
+            foreach (var actionDescriptor in actionDescriptors)
             {
-                if (!item.DisplayName.Contains(nameof(FunctionController), StringComparison.OrdinalIgnoreCase))
+                if (!actionDescriptor.DisplayName.Contains(
+                    nameof(FunctionController),
+                    StringComparison.OrdinalIgnoreCase))
                 {
                     continue;
                 }
@@ -66,9 +68,34 @@ namespace SampleApp.Controllers
                 _logger.LogInformation(
                     0,
                     "{DescriptorName} ({DescriptorId}): {Template}",
-                    item.DisplayName,
-                    item.Id,
-                    item.AttributeRouteInfo.Template);
+                    actionDescriptor.DisplayName,
+                    actionDescriptor.Id,
+                    actionDescriptor.AttributeRouteInfo.Template);
+                foreach (var kvp in actionDescriptor.RouteValues)
+                {
+                    _logger.LogInformation(
+                        1,
+                        "Route Value '{RouteValueKey}': '{RouteValueValue}'",
+                        kvp.Key,
+                        kvp.Value);
+                }
+
+                foreach (var constraint in actionDescriptor.ActionConstraints)
+                {
+                    _logger.LogInformation(2, "Constraint: '{ConstraintType}'", constraint.GetType());
+                }
+
+                foreach (var filter in actionDescriptor.FilterDescriptors)
+                {
+                    if (filter.Filter is ServiceFilterAttribute serviceFilter)
+                    {
+                        _logger.LogInformation(3, "Filter: '{FilterType}'", serviceFilter.ServiceType);
+                    }
+                    else
+                    {
+                        _logger.LogInformation(4, "Filter: '{FilterType}'", filter.Filter.GetType());
+                    }
+                }
             }
 
             return RedirectToAction(nameof(Index));

--- a/src/SampleApp/FunctionsRouteTable.cs
+++ b/src/SampleApp/FunctionsRouteTable.cs
@@ -58,17 +58,17 @@ namespace SampleApp
 
         public class Entry
         {
-            public Entry(string template, string reciever, string id, Func<HttpContext, Task<IActionResult>> execute)
+            public Entry(string template, string receiver, string id, Func<HttpContext, Task<IActionResult>> execute)
             {
                 Template = template;
-                Reciever = reciever;
+                Receiver = receiver;
                 Id = id;
                 Execute = execute;
             }
 
             public string Template { get; }
 
-            public string Reciever { get; }
+            public string Receiver { get; }
 
             // !!! Always null in this sample. Would be used in real life.
             public string Id { get; }

--- a/src/SampleApp/SampleApp.csproj
+++ b/src/SampleApp/SampleApp.csproj
@@ -4,14 +4,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.0-preview1-final" />
-    <PackageReference Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="2.1.0-preview1-final" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.0-preview1-final" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.1.0-preview1-final" />
-    <PackageReference Include="Microsoft.AspNetCore.WebHooks.Receivers.GitHub" Version="1.0.0-preview1-final" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.1.0-preview1-final" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.0-preview2-final" />
+    <PackageReference Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="2.1.0-preview2-final" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.0-preview2-final" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.1.0-preview2-final" />
+    <PackageReference Include="Microsoft.AspNetCore.WebHooks.Receivers.GitHub" Version="1.0.0-preview2-final" />
   </ItemGroup>
 </Project>

--- a/src/SampleApp/Startup.cs
+++ b/src/SampleApp/Startup.cs
@@ -8,24 +8,17 @@ namespace SampleApp
 {
     public class Startup
     {
-        public Startup(IConfiguration configuration)
-        {
-            Configuration = configuration;
-        }
-
-        public IConfiguration Configuration { get; }
-
-        public FunctionsRouteTable RouteTable { get; } = new FunctionsRouteTable();
+        private readonly FunctionsRouteTable _routeTable = new FunctionsRouteTable();
 
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddSingleton(RouteTable);
-            services.AddSingleton<IActionDescriptorChangeProvider>(RouteTable);
+            services.AddSingleton(_routeTable);
+            services.AddSingleton<IActionDescriptorChangeProvider>(_routeTable);
 
             services
                 .AddMvc(options =>
                 {
-                    options.Conventions.Add(new DuplicateConvention(RouteTable));
+                    options.Conventions.Add(new DuplicateConvention(_routeTable));
                 })
                 .AddGitHubWebHooks();
         }

--- a/src/SampleApp/appsettings.json
+++ b/src/SampleApp/appsettings.json
@@ -1,4 +1,5 @@
 ﻿{
+  "WebHooks:GitHub:SecretKey:default": "0123456789012345",
   "Logging": {
     "IncludeScopes": false,
     "LogLevel": {


### PR DESCRIPTION
- change referenced versions
  - update instructions for use
- collapse `FunctionController` to a single action that handles all WebHook requests
  - log more information in that action
- remove `AttributeRouteModel.Template` hack and pass receiver and id in `RouteValues`
- log more information in `HomeController.DumpRoutes(...)` action

nits:
- correct `FunctionsRouteTable+Entry.Receiver` spelling mistake
- remove `Startup.Configuration` and `RouteTable` properties; `static`s were unreferenced
- rename a few variables
- add fake secret key to enable testing a few more scenarios